### PR TITLE
Fix GlideImage build warning

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
     id 'org.jetbrains.kotlin.plugin.serialization'
-    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -4,5 +4,4 @@ plugins {
     id 'com.android.library' version '8.10.1' apply false
     id 'org.jetbrains.kotlin.android' version '2.1.21' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '2.1.21' apply false
-    id 'org.jetbrains.kotlin.plugin.compose' version '2.1.21' apply false
 }


### PR DESCRIPTION
## Summary
- remove `org.jetbrains.kotlin.plugin.compose` plugin references

This resolves the GlideImage compilation warning caused by mixing JetBrains Compose plugin with Jetpack Compose.

## Testing
- `gradle` build (fails: **SDK location not found**)


------
https://chatgpt.com/codex/tasks/task_e_6847c00a907c832b83cb0017060f41c6